### PR TITLE
Added in service to build up RW paths of indexed objects

### DIFF
--- a/web/onos-gui/src/app/onos-config/config-view/config-view.component.html
+++ b/web/onos-gui/src/app/onos-config/config-view/config-view.component.html
@@ -29,7 +29,7 @@
 
 <onos-path-bar id="config-path-panel" [path]="selectedPath">
 </onos-path-bar>
-<onos-string-value *ngIf="selectedValue?.valueType === 1"
+<onos-string-value *ngIf="selectedValue?.valueType === 1 || selectedRwPath?.getValueType() === 1"
                    [valueDetails]="selectedValue"
                    (valueEdited)="addToEditedValues(selectedPath, selectedValue, $event)">
 </onos-string-value>
@@ -65,7 +65,8 @@
             <svg:g #readWriteLayer
                    onos-layer-svg [layerId]="type + version + ''"
                    [classes]="['rwpaths']"
-                   [visible]="changeIdsVisible.get(RWPATHS)" [layerType]="3">
+                   [visible]="changeIdsVisible.get(RWPATHS)" [layerType]="3"
+                   (editRequestedLayer)="pathSelected($event)">
             </svg:g>
         </svg:g>
     </svg:svg>

--- a/web/onos-gui/src/app/onos-config/config-view/config-view.component.ts
+++ b/web/onos-gui/src/app/onos-config/config-view/config-view.component.ts
@@ -31,8 +31,9 @@ import {TreeLayoutService} from '../tree-layout.service';
 import {PathDetails} from './layer-svg/layer-svg.component';
 import {ValueDetails} from '../change-value.util';
 import {
-    ChangeValue,
+    ChangeValue, ReadWritePath,
 } from '../proto/github.com/onosproject/onos-config/pkg/northbound/admin/admin_pb';
+import {ModelTempIndexService} from './model-temp-index.service';
 
 export const OPSTATE = 'opstate';
 export const RWPATHS = 'rwpaths';
@@ -49,6 +50,10 @@ export const CONFIGNAME = 'configName';
         {
             provide: TreeLayoutService,
             useValue: new TreeLayoutService()
+        },
+        {
+            provide: ModelTempIndexService,
+            useValue: new ModelTempIndexService()
         }
     ]
 })
@@ -67,6 +72,7 @@ export class ConfigViewComponent implements OnInit, OnChanges, OnDestroy {
     create_pending_confirm: string = '';
     selectedPath = '/';
     selectedValue: ValueDetails = undefined;
+    selectedRwPath: ReadWritePath;
 
     // Constants - have to declare a viable to hold a constant so it can be used in HTML(?!?!)
     public OPSTATE = OPSTATE;
@@ -78,6 +84,7 @@ export class ConfigViewComponent implements OnInit, OnChanges, OnDestroy {
         private tree: TreeLayoutService,
         protected ar: ActivatedRoute,
         protected is: IconService,
+        private modelTmpIndex: ModelTempIndexService,
     ) {
         this.is.loadIconDef('checkMark');
         this.is.loadIconDef('xMark');
@@ -104,6 +111,7 @@ export class ConfigViewComponent implements OnInit, OnChanges, OnDestroy {
 
     ngOnDestroy(): void {
         this.tree.resetAll();
+        this.modelTmpIndex.clearAll();
         console.log('ConfigViewComponent destroyed and Tree Service reset');
     }
 
@@ -157,6 +165,7 @@ export class ConfigViewComponent implements OnInit, OnChanges, OnDestroy {
     pathSelected(pathDetails: PathDetails) {
         this.selectedPath = pathDetails.abspath;
         this.selectedValue = pathDetails.value;
+        this.selectedRwPath = pathDetails.readWritePath;
     }
 
     activatePendingLayer(configName: string, path: string): void {

--- a/web/onos-gui/src/app/onos-config/config-view/container-svg/container-svg.component.css
+++ b/web/onos-gui/src/app/onos-config/config-view/container-svg/container-svg.component.css
@@ -38,7 +38,7 @@ use#editicon {
 }
 
 #container {
-    cursor: grab;
+    cursor: default;
 }
 
 /* For the config class */

--- a/web/onos-gui/src/app/onos-config/config-view/container-svg/container-svg.component.html
+++ b/web/onos-gui/src/app/onos-config/config-view/container-svg/container-svg.component.html
@@ -25,7 +25,7 @@
 </svg:defs>
 
 <svg:g id="container" [ngClass]="classes.join(' ')" xmlns:svg="http://www.w3.org/2000/svg" width="160" height="80"
-         [attr.transform]="'translate(' + containerX + ',' + containerY + '), scale(' + containerScale + ')'">
+         [attr.transform]="'translate(' + node.x + ',' + node.y + '), scale(' + containerScale + ')'">
     <svg:rect id="box" width="160"
               [attr.height]="boxHeight"
               [attr.rx]="classes.includes('leaf')?0:5"

--- a/web/onos-gui/src/app/onos-config/config-view/container-svg/container-svg.component.ts
+++ b/web/onos-gui/src/app/onos-config/config-view/container-svg/container-svg.component.ts
@@ -25,6 +25,7 @@ import {
     ChangeValueType,
     ReadWritePath
 } from '../../proto/github.com/onosproject/onos-config/pkg/northbound/admin/admin_pb';
+import {ConfigNode} from '../../tree-layout.service';
 
 @Component({
     selector: '[onos-container-svg]',
@@ -35,8 +36,7 @@ export class ContainerSvgComponent implements OnChanges {
     @Input() relpath: string;
     @Input() abspath: string;
     @Input() parentpath: string;
-    @Input() containerX: number = 0;
-    @Input() containerY: number = 0;
+    @Input() node: ConfigNode;
     @Input() containerScale: number = 1.0;
     @Input() value: Uint8Array | string;
     @Input() valueType: ChangeValueType;

--- a/web/onos-gui/src/app/onos-config/config-view/layer-svg/layer-svg.component.css
+++ b/web/onos-gui/src/app/onos-config/config-view/layer-svg/layer-svg.component.css
@@ -13,3 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#dragbox {
+    opacity: 0;
+    cursor: grab;
+}

--- a/web/onos-gui/src/app/onos-config/config-view/layer-svg/layer-svg.component.html
+++ b/web/onos-gui/src/app/onos-config/config-view/layer-svg/layer-svg.component.html
@@ -18,8 +18,7 @@
     <svg:desc>Layer: {{layerId}} {{description}} {{changeTime | date: 'medium'}}</svg:desc>
     <svg:g *ngFor="let node of nodelist | keyvalue; let i = index">
         <svg:g onos-container-svg
-               [containerX]="node.value.node.x"
-               [containerY]="node.value.node.y"
+               [node]="node.value.node"
                [relpath]="node.value.relPath"
                [value]="node.value.value"
                [valueType]="node.value.valueType"
@@ -27,9 +26,13 @@
                [parentpath]="node.value.parentPath"
                [abspath]="node.key"
                [classes]="classes"
-               (containerEditRequested)="requestEditLayer($event, node.value.value, node.value.valueType, node.value.valueTypeOpts)"
-                onosDraggableContainer [draggableNode]="node.value.node">
+               (containerEditRequested)="requestEditLayer($event, node.value.value, node.value.valueType, node.value.valueTypeOpts, node.value.rwPath)"
+                >
         </svg:g>
+        <svg:rect id="dragbox" width="100" height="20" [attr.transform]="'translate(' + node.value.node.x + ',' + node.value.node.y + ')'"
+                  onosDraggableContainer [draggableNode]="node.value.node">
+            <svg:desc>Using a separate invisible target for dragging</svg:desc>
+        </svg:rect>
     </svg:g>
     <svg:path *ngFor="let branch of linkList | keyvalue" stroke-width="2" stroke="#a9aba0" fill-opacity="0"
               [attr.d]="curveCalculator(branch.value.link)">

--- a/web/onos-gui/src/app/onos-config/config-view/model-temp-index.service.spec.ts
+++ b/web/onos-gui/src/app/onos-config/config-view/model-temp-index.service.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+
+import {ModelTempIndexService} from './model-temp-index.service';
+import {
+    ChangeValueType,
+    ModelInfo,
+    ReadWritePath
+} from '../proto/github.com/onosproject/onos-config/pkg/northbound/admin/admin_pb';
+
+describe('ModelTempIndexService', () => {
+    const pathArray: Array<ReadWritePath> = Array(2);
+
+    const rwPath1 = new ReadWritePath();
+    rwPath1.setPath('/a/b[x=*,y=*]/c/d[z=*]/e');
+    rwPath1.setDescription('Test leaf e');
+    rwPath1.setValueType(ChangeValueType.STRING);
+    pathArray[0] = rwPath1;
+
+    const rwPath2 = new ReadWritePath();
+    rwPath2.setPath('/a/b[x=*,y=*]/c/d[z=*]/f');
+    rwPath2.setDescription('Test leaf e');
+    rwPath2.setValueType(ChangeValueType.STRING);
+    pathArray[1] = rwPath2;
+
+    const rwPath3 = new ReadWritePath();
+    rwPath3.setPath('/a/g/h/i');
+    rwPath3.setDescription('Test leaf i');
+    rwPath3.setValueType(ChangeValueType.STRING);
+    pathArray[2] = rwPath3;
+
+    const rwPath4 = new ReadWritePath();
+    rwPath4.setPath('/a/p[n=*]/q/r[n=*]/s');
+    rwPath4.setDescription('Test leaf s');
+    rwPath4.setValueType(ChangeValueType.STRING);
+    pathArray[3] = rwPath4;
+
+    const testModelInfo = new ModelInfo();
+    testModelInfo.setName('testModelInfo');
+    testModelInfo.setReadWritePathList(pathArray);
+
+    beforeEach(() => TestBed.configureTestingModule({
+        providers: [
+            {
+                provide: ModelTempIndexService,
+                useClass: ModelTempIndexService
+            }
+        ]
+    }));
+
+    it('should be created', () => {
+        const service: ModelTempIndexService = TestBed.get(ModelTempIndexService);
+        expect(service).toBeTruthy();
+    });
+
+    it('should add model info', () => {
+        const service: ModelTempIndexService = TestBed.get(ModelTempIndexService);
+        service.addModelInfo(testModelInfo);
+        expect(service.modelInfo.getReadWritePathList().length).toBe(4);
+    });
+
+    it('should calculate extra paths', () => {
+        const service: ModelTempIndexService = TestBed.get(ModelTempIndexService);
+        service.addModelInfo(testModelInfo);
+
+        service.addIndex('/a/b[x=1,y=1]/c/d[z=1/0]/e');
+        service.addIndex('/a/b[x=1,y=2]/c/d[z=1/0]/f');
+        service.addIndex('/a/b[x=2,y=1]/c/d[z=1/0]/f');
+        service.addIndex('/a/b[x=2,y=2]/c/d[z=1/0]/f');
+        service.addIndex('/a/b[x=1,y=2]/c/d[z=2/0]/f');
+        service.addIndex('/a/g/h/i');
+        service.addIndex('/a/p[n=1]/q/r[n=1]/s');
+
+        expect(service.indexNames.length).toEqual(6);
+
+        const extraPaths = service.calculateExtraPaths();
+        expect(extraPaths.length).toBe(11);
+        expect(extraPaths[0].getPath()).toEqual('/a/b[x=1,y=1]/c/d[z=1/0]/e');
+        expect(extraPaths[1].getPath()).toEqual('/a/b[x=1,y=1]/c/d[z=1/0]/f');
+        expect(extraPaths[2].getPath()).toEqual('/a/b[x=1,y=2]/c/d[z=1/0]/e');
+        expect(extraPaths[3].getPath()).toEqual('/a/b[x=1,y=2]/c/d[z=1/0]/f');
+        expect(extraPaths[4].getPath()).toEqual('/a/b[x=2,y=1]/c/d[z=1/0]/e');
+        expect(extraPaths[5].getPath()).toEqual('/a/b[x=2,y=1]/c/d[z=1/0]/f');
+        expect(extraPaths[6].getPath()).toEqual('/a/b[x=2,y=2]/c/d[z=1/0]/e');
+        expect(extraPaths[7].getPath()).toEqual('/a/b[x=2,y=2]/c/d[z=1/0]/f');
+        expect(extraPaths[8].getPath()).toEqual('/a/b[x=1,y=2]/c/d[z=2/0]/e');
+        expect(extraPaths[9].getPath()).toEqual('/a/b[x=1,y=2]/c/d[z=2/0]/f');
+        expect(extraPaths[10].getPath()).toEqual('/a/p[n=1]/q/r[n=1]/s');
+    });
+});

--- a/web/onos-gui/src/app/onos-config/config-view/model-temp-index.service.ts
+++ b/web/onos-gui/src/app/onos-config/config-view/model-temp-index.service.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable} from '@angular/core';
+import {
+    ModelInfo,
+    ReadWritePath
+} from '../proto/github.com/onosproject/onos-config/pkg/northbound/admin/admin_pb';
+
+const EXTRACT_INDEX = /(=.+?[,\]])/;
+const EXTRACT_INDEX_VALUE = /([^=,\]])+?/; // Causes ng test to stop running
+
+
+/**
+ * This is a service used to temporarily augment the RW paths of a model with
+ * the indices of actual instance
+ * e.g. if there is an interface [name=0/1] in some layer, then the RW paths
+ * should list everything that's already under the interface [name=*] again
+ * under this named interface.
+ *
+ * This is used by the layer-svg component
+ * - the RW paths layer calls on addModelInfo() when it is loaded
+ * - each one of the config layers calls on addIndex() with its real paths
+ * - when RW Paths layer is made visible it calls on calculateExtraPaths()
+ * - when the ConfigViewComponent is being destroyed - it calls clear all
+ *
+ * The service is not loaded until first used by a ConfigViewComponent
+ * It stays alive even if this component is destroyed
+ * It is reused again by other uses of the ConfigViewComponent
+ **/
+@Injectable()
+export class ModelTempIndexService {
+
+    indexNames: Array<string>;
+    modelInfo: ModelInfo;
+    extractIndex: RegExp;
+    extractIndexValue: RegExp;
+
+    constructor() {
+        this.indexNames = Array(0);
+        this.extractIndex = new RegExp(EXTRACT_INDEX, 'g');
+        this.extractIndexValue = new RegExp(EXTRACT_INDEX_VALUE);
+    }
+
+    calculateExtraPaths(): Array<ReadWritePath> {
+        const extraPaths = Array<ReadWritePath>(0);
+        console.log('Calculating extra Model indices for',
+            this.modelInfo.getName(), this.indexNames.length);
+
+        this.indexNames.forEach((idxName) => {
+            let match: string[];
+            let idxNameWildcard = idxName;
+            while (match = this.extractIndex.exec(idxName)) {
+                const r1 = match[1].replace(/=.*,/, '=*,').replace(/=.*]/, '=*]');
+                idxNameWildcard = idxNameWildcard.replace(match[1], r1);
+            }
+            this.modelInfo.getReadWritePathList().forEach((rwMp) => {
+                if (rwMp.getPath().startsWith(idxNameWildcard)) {
+                    const fullPath = rwMp.getPath().replace(idxNameWildcard, idxName);
+                    const extraPath = new ReadWritePath();
+                    extraPath.setPath(fullPath);
+                    extraPath.setValueType(rwMp.getValueType());
+                    extraPath.setDescription(rwMp.getDescription());
+                    extraPath.setDefault(rwMp.getDefault());
+                    extraPath.setLengthList(rwMp.getLengthList());
+                    extraPath.setMandatory(rwMp.getMandatory());
+                    extraPath.setRangeList(rwMp.getRangeList());
+                    extraPath.setUnits(rwMp.getUnits());
+                    extraPaths.push(extraPath);
+                }
+            });
+        });
+        return extraPaths;
+    }
+
+    clearAll() {
+        const oldLen = this.indexNames.length;
+        this.indexNames.length = 0;
+        console.log('Model Index cleared', oldLen);
+    }
+
+    addIndex(abspath: string) {
+        const hasIndex = abspath.lastIndexOf(']');
+        const toLastIdx = abspath.slice(0, hasIndex + 1);
+        if (hasIndex > 0 && !this.indexNames.includes(toLastIdx)) {
+            this.indexNames.push(toLastIdx);
+        }
+    }
+
+    addModelInfo(modelInfo: ModelInfo) {
+        this.modelInfo = modelInfo;
+    }
+}

--- a/web/onos-gui/src/app/onos-config/pending-net-change.service.spec.ts
+++ b/web/onos-gui/src/app/onos-config/pending-net-change.service.spec.ts
@@ -106,10 +106,10 @@ describe('PendingNetChangeService', () => {
         expect(gnmiPaths[4].getKeyMap()['map_']['severity']['key']).toEqual('severity');
         expect(gnmiPaths[4].getKeyMap()['map_']['severity']['value']).toEqual('2');
 
-        console.log('KeyMap', Object.keys(gnmiPaths[4].getKeyMap()));
-        for (const k of Object.keys(gnmiPaths[4].getKeyMap())) {
-            console.log('item', k, gnmiPaths[4].getKeyMap()[k]);
-        }
+        // console.log('KeyMap', Object.keys(gnmiPaths[4].getKeyMap()));
+        // for (const k of Object.keys(gnmiPaths[4].getKeyMap())) {
+        //     console.log('item', k, gnmiPaths[4].getKeyMap()[k]);
+        // }
     });
 
 });


### PR DESCRIPTION
When you go to edit a configuration what happens when you want to create an attribute that hasn't been edited before.
A. You view the RW Paths layer

but previously the path was shown only with a wildcard index and did not allow you to edit on an existing indexed object
e.g.
It presented **/interfaces/interface[name=*]/config/health-indicator**
when what you really wanted to edit was
**/interfaces/interface[name=1/0]/config/health-indicator**

Now with this service the RW paths goes through all of the indexes and creates temporary RW paths for each one.