### PR TITLE
In Config Dashboard do not watch Device Changes directly - too resource intensive

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,12 +5,16 @@ with an atomix controller deployed in a namespace.
 `onos-gui` Helm chart is based on Helm 3.0 version, with no need for the Tiller pod to be present.
 
 > The onos-gui deployment consists of 2 containers:
+>
 > * onos-gui - containing an nginx web server and the compiled GUI
 > * onos-envoy - containing a grpc-web proxy for connecting to onos-topo, onos-config etc.
 
 If you don't have a cluster running and want to try on your local machine please follow first 
 the [Kubernetes] setup steps outlined in [deploy with Helm](https://docs.onosproject.org/developers/deploy_with_helm/).
 The following steps assume you have the setup outlined in that page, including the `micro-onos` namespace configured.
+
+> Note: if deploying the GUI on top of `onit` that its default namespace is `onos`,
+> so any mention of `micro-onos` below should be replaced with `onos` 
 
 ## Installing the Chart
 To install the chart in the `micro-onos` namespace run from the root directory of the `onos-helm-charts` repo the command:

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -2,8 +2,26 @@
 This document provides an overview of the tools and packages needed to work on and to build onos-gui.
 Developers are expected to have these tools installed on the machine where the project is built.
 
+## Reusing tools from an existing ONOS installation
+If you already have the legacy ONOS project code checked out and built using Bazel
+on your system you already have all the tools you need.
+Add the following 2 entries to your $PATH environment variable to give access
+to the `npm` and the `ng` command respectively
+
+* [bazel output_base]/external/nodejs_linux_amd64/bin/nodejs/bin
+* ~/onos/web/gui2/node_modules/@angular/cli/bin
+
+where [bazel output_base] above can be found from running the command: `bazel info output_base`
+
+After setting the PATH it should be possible to see the version of **node** and **npm**:
+```bash
+node -v
+npm -v
+which ng
+```
+
 ## NodeJS
-Install the latest Long Term Support version of NodeJS on your system.
+If legacy ONOS is not available install the latest Long Term Support version of NodeJS on your system.
 
 * Downloads are available from <https://nodejs.org/en/download/>
 * Instructions for installing on Linux are at <https://github.com/nodejs/help/wiki/Installation>
@@ -16,7 +34,7 @@ npm -v
 ```
 
 ## Angular CLI
-Angular CLI provides the **ng** tools. Installation instructions are at
+If legacy ONOS is not available install Angular CLI to provide the **ng** tools. Installation instructions are at
 <https://angular.io/guide/setup-local>
 
 The following command can be run from any folder:
@@ -48,7 +66,7 @@ git remote -v
 ```
 
 ## Set up Angular for local development
-After this install (and after changing to the web/onos-gui folder) it should be
+After this install (and after changing to the `web/onos-gui` folder) it should be
 possible to see the Angular CLI version:
 ```bash
 cd web/onos-gui
@@ -57,11 +75,6 @@ ng version
 This should give a result like:
 
 ```bash
-Your global Angular CLI version (8.1.2) is greater than your local
-version (7.0.7). The local Angular CLI version is used.
-
-To disable this warning use "ng config -g cli.warnings.versionMismatch false".
-
      _                      _                 ____ _     ___
     / \   _ __   __ _ _   _| | __ _ _ __     / ___| |   |_ _|
    / △ \ | '_ \ / _` | | | | |/ _` | '__|   | |   | |    | |
@@ -69,14 +82,13 @@ To disable this warning use "ng config -g cli.warnings.versionMismatch false".
  /_/   \_\_| |_|\__, |\__,_|_|\__,_|_|       \____|_____|___|
                 |___/
     
-
-Angular CLI: 7.0.7
-Node: 12.6.0
+Angular CLI: 8.3.20
+Node: 10.16.0
 OS: linux x64
-Angular: 7.0.4
+Angular: 8.2.14
 ... animations, common, compiler, compiler-cli, core, forms
-... http, language-service, platform-browser
-... platform-browser-dynamic, router
+... language-service, platform-browser, platform-browser-dynamic
+... router
 ...
 ``` 
 
@@ -102,7 +114,7 @@ Some form of an integrated development environment that supports Web Development
 with TypeScript is also recommended. The core team uses the Intellij
 [WebStorm IDE] from JetBrains, but there are many other options.
 The [Atom] editor is a lightweight solution supporting TypeScript and Git integration.
-[Visual Studio Code] is another option that supports TypeScript..
+[Visual Studio Code] is another option that supports TypeScript.
 
 ## License
 The project requires that all Typescript source files are properly annotated using the Apache 2.0 License.

--- a/docs/run.md
+++ b/docs/run.md
@@ -21,20 +21,27 @@ which should make the GUI available at [http://onos-gui:8181](http://onos-gui:81
 > The port-forward command can be given with `--address=<interfaceip>` matching
 > the entry in `/etc/hosts` if the GUI needs to be accessible outside the machine.
 
+![onos-gui-models-view](images/onos-gui-models-view.png)
+
 The browser connects to onos-gui over HTTP 1.1 to retrieve the Angular compiled
 static files.
 
-When the **List onos-config capabilities** button is pressed:
+The **Config view dashboard** is the default, and shows all the devices and their network changes
+in a tabular layout. Other views are available through the menu on the top left or
+through hyperlinks (e.g. on the device).
 
-1. A grpc-web request is formed and sent as a POST to [http://onos-gui/gnmi.gNMI/Capabilities](http://onos-gui/gnmi.gNMI/Capabilities)
-1. This is forwarded by a `proxy_pass` declaration in `nginx.conf` to [http://onos-config-envoy:8080](http://onos-config-envoy:8080)
+When the **Config view dashboard** is loaded:
+
+1. A grpc-web request is formed and sent as a POST to [http://onos-gui:8181/onos-config/onos.config.diags.ChangeService/ListNetworkChanges](http://onos-gui:8181/onos-config/onos.config.diags.ChangeService/ListNetworkChanges)
+1. This is forwarded by a `proxy_pass` declaration in `nginx.conf` to [http://localhost:8081](http://localhost:8081)
 1. This is converted in to a gRPC request by Envoy Proxy server's grpc-web filter
 1. and is forwarded to [https://onos-config:5150](https://onos-config:5150) as a gRPC request
 1. onos-config sends back the response to envoy asynchronously as a gRPC response
 1. Envoy's grpc-web service turns it in to a grpc-web response and sends it back to nginx
 1. nginx sends the response back to the browser and the callback function is called
-1. Inside the browser the callback updates the `capabilities` object inside the AppComponent
-1. the binding in the app.component.html page is alerted to the updated value and refreshes the display
+1. Inside the browser the callback updates the `networkChanges` object inside the ConfigDashboardComponent
+1. the binding in the config-dashboard.component.html page is alerted to the updated value and refreshes the display
+1. similar calls are made to load the `snapshots` and `devices`
 
 ## Developer mode
 To run the GUI locally on a development machine
@@ -45,13 +52,11 @@ To run the GUI locally on a development machine
 in 2 separate terminals
 ```bash
 kubectl -n micro-onos port-forward $(kubectl -n micro-onos get pods -l type=gui -o name) 8080:8080
-kubectl -n micro-onos port-forward $(kubectl -n micro-onos get pods -l type=gui -o name) 8181:8181
+kubectl -n micro-onos port-forward $(kubectl -n micro-onos get pods -l type=gui -o name) 8081:8081
 ```
 
 - run the Angular CLI in `ng serve --configuration=kind` mode from the web/onos-gui folder
 - browse to [http://localhost:4200](http://localhost:4200) - this does not require `onos-gui` hostname.
 - ensure that the models page shows the 4 loaded model plugins (this
 ensures that the gRPC requests are proxied correctly through the envoy proxy)
-
-![onos-gui-models-view](images/onos-gui-models-view.png)
 

--- a/web/onos-gui/src/app/onos-config/config-dashboard/config-dashboard.component.html
+++ b/web/onos-gui/src/app/onos-config/config-dashboard/config-dashboard.component.html
@@ -55,7 +55,7 @@
             <input type="button" value="Compact.." (click)="compactChangesDialog()">
             <label><small>Retention </small></label>
             <select [(ngModel)]="retenionSecs">
-                <option value="0">none</option>
+                <option value="0">0 sec</option>
                 <option value="3600">1 hr</option>
                 <option value="21600">6 hrs</option>
                 <option value="43200">12 hrs</option>
@@ -70,7 +70,7 @@
         *ngFor="let nwchId of networkChanges | keyvalue:nwChangeIncreasingAge; let i = index"
         onos-network-change [networkChange]="nwchId.value"
         [deviceSortCriterion]="deviceSortCriterion"
-        (dcSelected)="deviceChangeSelected($event, nwchId.value)">
+        (dcSelected)="deviceChangeSelected($event, nwchId.key)">
     </tr>
     <tr class="nw-ss-row" onos-network-snapshot
         [deviceSortCriterion]="deviceSortCriterion"

--- a/web/onos-gui/src/app/onos-config/config-dashboard/device-change/device-change.component.html
+++ b/web/onos-gui/src/app/onos-config/config-dashboard/device-change/device-change.component.html
@@ -17,5 +17,5 @@
      [ngClass]="getStatusClass()"
      [title]="getTooltip()"
      (click)="selected.emit(true)">
-    {{deviceService.deviceChangeMap.get(deviceChangeName())?.getChange().getValuesList().length}}
+    {{change?.getValuesList().length}}
 </div>

--- a/web/onos-gui/src/app/onos-config/config-dashboard/device-change/device-change.component.ts
+++ b/web/onos-gui/src/app/onos-config/config-dashboard/device-change/device-change.component.ts
@@ -16,12 +16,9 @@
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {DeviceService} from '../../device.service';
-import {
-    Phase,
-    Reason,
-    State
-} from '../../proto/github.com/onosproject/onos-config/api/types/change/types_pb';
 import {StatusUtil} from '../../status.util';
+import {Change} from '../../proto/github.com/onosproject/onos-config/api/types/change/device/types_pb';
+import {Status} from '../../proto/github.com/onosproject/onos-config/api/types/change/types_pb';
 
 @Component({
     selector: '[onos-device-change]',
@@ -32,6 +29,8 @@ export class DeviceChangeComponent {
     @Input() deviceChangeId: string;
     @Input() deviceVersion: string;
     @Input() networkChangeId: string;
+    @Input() change: Change;
+    @Input() state: Status;
     @Output() selected  = new EventEmitter<boolean>();
 
     constructor(
@@ -44,17 +43,10 @@ export class DeviceChangeComponent {
     }
 
     getStatusClass(): string[] {
-        const deviceChange = this.deviceService.deviceChangeMap.get(this.deviceChangeName());
-        if (deviceChange === undefined) {
-            return ['undefined'];
-        }
-        return StatusUtil.statusToStrings(deviceChange.getStatus());
+        return StatusUtil.statusToStrings(this.state);
     }
 
     getTooltip(): string[] {
-        const deviceChange = this.deviceService.deviceChangeMap.get(this.deviceChangeName());
-        if (deviceChange !== undefined) {
-            return StatusUtil.statusToStrings(deviceChange.getStatus());
-        }
+        return [this.deviceChangeName()];
     }
 }

--- a/web/onos-gui/src/app/onos-config/config-dashboard/network-change/network-change.component.html
+++ b/web/onos-gui/src/app/onos-config/config-dashboard/network-change/network-change.component.html
@@ -24,5 +24,7 @@
     onos-device-change [deviceChangeId]="device.value.getId()"
     [deviceVersion]="device.value.getVersion()"
     [networkChangeId]="networkChange.getId()"
+    [change]="getChangeByName(device.value.getId(), device.value.getVersion())"
+    [state]="networkChange.getStatus()"
     (selected)="itemSelected(networkChange.getId(), device.value.getId(), device.value.getVersion())">
 </td>

--- a/web/onos-gui/src/app/onos-config/config-dashboard/network-change/network-change.component.ts
+++ b/web/onos-gui/src/app/onos-config/config-dashboard/network-change/network-change.component.ts
@@ -31,7 +31,7 @@ export class NetworkChangeComponent implements OnInit {
     @Input() networkChange: NetworkChange;
     @Input() deviceSortCriterion: (a: KeyValue<string, Device>, b: KeyValue<string, Device>) => number
         = DeviceService.deviceSorterForwardAlpha;
-    @Output() dcSelected = new EventEmitter<string>();
+    @Output() dcSelected = new EventEmitter<Change>();
     created: number;
 
     constructor(
@@ -43,14 +43,8 @@ export class NetworkChangeComponent implements OnInit {
         this.created = (new Date()).setTime(this.networkChange.getCreated().getSeconds() * 1000);
     }
 
-    hasChangeByName(name: string): boolean {
-        this.networkChange.getChangesList().forEach((ch: Change) => {
-            if (ch.getDeviceId() === name) {
-                console.log('Returning true for', name, 'on', this.networkChange.getId());
-                return true;
-            }
-        });
-        return false;
+    getChangeByName(name: string, version: string): Change {
+        return this.networkChange.getChangesList().find((c) => c.getDeviceId() === name && c.getDeviceVersion() === version);
     }
 
     getStatusClass(): string[] {
@@ -72,6 +66,6 @@ export class NetworkChangeComponent implements OnInit {
     }
 
     itemSelected(nwChangeId: string, deviceId: string, version: string) {
-        this.dcSelected.emit(nwChangeId  + ':' + deviceId + ':' + version);
+        this.dcSelected.emit(this.getChangeByName(deviceId, version));
     }
 }

--- a/web/onos-gui/src/app/onos-config/device-change-details/device-change-details.component.html
+++ b/web/onos-gui/src/app/onos-config/device-change-details/device-change-details.component.html
@@ -23,49 +23,7 @@
                            iconId="close" iconSize="20"
                            (click)="close()"></onos-icon>
             </div>
-            <h2 class="editable clickable">{{detailsData?.getId()}}</h2>
-            <div class="top-content">
-                <div class="top-tables">
-                    <div class="left">
-                        <table>
-                            <tbody>
-                            <tr>
-                                <td class="label" width="110">Created :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.created | date:'medium'}}</td>
-                                <td class="label" width="110">Phase :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.getStatus() | changeStatus:[1]}}</td>
-                            </tr>
-                            <tr>
-                                <td class="label" width="110">Updated :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.updated | date:'medium'}}</td>
-                                <td class="label" width="110">State :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.getStatus() | changeStatus:[0]}}</td>
-                            </tr>
-                            <tr>
-                                <td class="label" width="110">Revision :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.getRevision()}}</td>
-                                <td class="label" width="110">Reason :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.getStatus() | changeStatus:[2]}}</td>
-                            </tr>
-                            <tr>
-                                <td class="label" width="110">Index :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.getIndex()}}</td>
-                                <td class="label" width="110">Message :</td>
-                                <td class="value"
-                                    width="80">{{detailsData?.getStatus().getMessage()}}</td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
+            <h2 class="editable clickable">{{id}}</h2>
             <hr>
         </div>
         <div class="middle">
@@ -78,7 +36,7 @@
                 </tr>
                 </thead>
                 <tbody id="path-list">
-                <tr *ngFor="let dcValue of detailsData?.getChange().getValuesList()">
+                <tr *ngFor="let dcValue of detailsData?.getValuesList()">
                     <td class="pathitem" [ngClass]="dcValue.getRemoved() ? 'removed':''">{{dcValue.getPath()}}</td>
                     <td>{{dcValue.getValue() | changeValue:30}}</td>
                 </tr>

--- a/web/onos-gui/src/app/onos-config/device-change-details/device-change-details.component.ts
+++ b/web/onos-gui/src/app/onos-config/device-change-details/device-change-details.component.ts
@@ -29,8 +29,7 @@ import {
     WebSocketService
 } from 'gui2-fw-lib';
 import {
-    ChangeValue,
-    DeviceChange
+    Change,
 } from '../proto/github.com/onosproject/onos-config/api/types/change/device/types_pb';
 import {animate, state, style, transition, trigger} from '@angular/animations';
 
@@ -60,7 +59,7 @@ import {animate, state, style, transition, trigger} from '@angular/animations';
 export class DeviceChangeDetailsComponent extends DetailsPanelBaseImpl implements OnInit, OnChanges {
     @Input() id: string; // Has to be repeated from base class
     // Output closeEvent is inherited
-    @Input() deviceChange: DeviceChange;
+    @Input() deviceChange: Change;
 
     constructor(
         protected fs: FnService,
@@ -79,10 +78,6 @@ export class DeviceChangeDetailsComponent extends DetailsPanelBaseImpl implement
         if (changes['id']) {
             this.closed = false;
             this.detailsData = this.deviceChange;
-            if (this.deviceChange !== undefined && this.deviceChange.getUpdated() !== undefined) {
-                this.detailsData['created'] = (new Date()).setTime(this.deviceChange.getCreated().getSeconds() * 1000);
-                this.detailsData['updated'] = (new Date()).setTime(this.deviceChange.getUpdated().getSeconds() * 1000);
-            }
         }
     }
 }

--- a/web/onos-gui/src/app/onos-topo/device-detail/device-detail.component.html
+++ b/web/onos-gui/src/app/onos-topo/device-detail/device-detail.component.html
@@ -40,6 +40,11 @@
                                     width="80">{{detailsData?.getVersion()}}</td>
                             </tr>
                             <tr>
+                                <td class="label" width="110">Type :</td>
+                                <td class="value"
+                                    width="80">{{detailsData?.getType()}}</td>
+                            </tr>
+                            <tr>
                                 <td class="label" width="110">Address</td>
                                 <td class="value"
                                     width="80">{{detailsData?.getAddress()}}</td>
@@ -58,7 +63,7 @@
                                 <td class="label" width="110">Configuration</td>
                                 <td class="value"
                                     width="80"><a
-                                    [routerLink]="['/config','configview', detailsData?.id + '-' + detailsData?.getVersion() ]">{{ detailsData?.id + '-' + detailsData?.getVersion() }}</a></td>
+                                    [routerLink]="['/config','configview', detailsData?.getId() + '-' + detailsData?.getVersion() ]">{{ detailsData?.getId() + '-' + detailsData?.getVersion() }}</a></td>
                             </tr>
                             </tbody>
                         </table>

--- a/web/onos-gui/src/app/onos-topo/devices-list/devices-list.component.html
+++ b/web/onos-gui/src/app/onos-topo/devices-list/devices-list.component.html
@@ -44,6 +44,10 @@
                         <onos-icon classes="active-sort" [iconSize]="10"
                                    [iconId]="sortIcon('version')"></onos-icon>
                     </td>
+                    <td colId="version" (click)="onSort('version')">Type
+                        <onos-icon classes="active-sort" [iconSize]="10"
+                                   [iconId]="sortIcon('type')"></onos-icon>
+                    </td>
                     <td colId="address" (click)="onSort('address')">Address
                         <onos-icon classes="active-sort" [iconSize]="10"
                                    [iconId]="sortIcon('address')"></onos-icon>
@@ -73,6 +77,7 @@
                     (click)="selectCallback($event, device.key, device.value)">
                     <td>{{ device.value.getId() }}</td>
                     <td>{{ device.value.getVersion() }}</td>
+                    <td>{{ device.value.getType() }}</td>
                     <td>{{ device.value.getAddress() }}</td>
                     <td>{{ device.value.getRevision() }}</td>
                     <td>{{ device.value.getTarget() }}</td>


### PR DESCRIPTION
If we watch the `Device changes` in Config Dashboard, it will open up a stream connection to
server for each device - above 10 devices this becomes unfeasible because it puts too much
of a burden on the `onos-config` pod

Instead display the list of `device changes` known from the `network change`. This will give
us access to their paths and values.

When we view individual devices in the Config View
we will watch the `Device Changes` there for an individual device